### PR TITLE
Allow Listener to now need `with` clause to work

### DIFF
--- a/examples/stream_position.py
+++ b/examples/stream_position.py
@@ -1,16 +1,19 @@
+"""
+In this example, we are streaming the car's position straight to a Matplotlib plot.
+You'll see the plot update as you drive around the track, with the car's path using
+a heatmap color to depict the speed.
+"""
 import sys
-
 from granturismo.intake import Listener
 import matplotlib.pyplot as plt
-import time
 
 if __name__ == '__main__':
   ip_address = sys.argv[1]
 
   # setup the plot styling
-  plt.ion()
-  fig, ax = plt.subplots(figsize=(10, 10))
-  ax.axis('off')
+  plt.ion() # allows us to continue to upate the plot
+  fig, ax = plt.subplots(figsize=(8, 8))
+  ax.axis('off') # hides the black border around the axis.
   plt.xticks([])
   plt.yticks([])
 
@@ -29,21 +32,22 @@ if __name__ == '__main__':
         # note, we're negating z so the map will appear int he same orientation as it does in the game's minimap
         x, z = packet.position.x, -packet.position.z
         if px is None:
-          px = x
-          pz = z
+          px, pz = x, z
+          continue
 
-        # here we're adding 3 points on top of each other so that the final point will have the correct coloring for the car's speed range.
-        # we're plotting (min speed, max speed, current speed) and matplotlib will adjust the color map so that the final (current speed)
-        # color is accurate
+        # here we're getting the ratio of how fast the car's going compared to it's max speed.
+        # we're multiplying by 3 to boost the colorization range.
         speed = min(1, packet.car_speed / packet.car_max_speed) * 3
-        print(f'{packet.car_speed:.1f}/{packet.car_max_speed:.1f} = {speed=}')
+        # Now use the "speed" ratio to select the color from the Matplotlib pallet
         color = plt.cm.plasma(speed)
+
+        # plot the current step
         plt.plot([px, x], [pz,  z], color=color)
+
+        # set the aspect ratios to be equal for x/z axis, this way the map doesn't look skewed
         plt.gca().set_aspect('equal', adjustable='box')
 
         # pause for a freakishly shot amount of time. We need a pause so that it'll trigger a graph update
         plt.pause(0.00000000000000000001)
 
         px, pz = x, z
-
-

--- a/examples/stream_suspension.py
+++ b/examples/stream_suspension.py
@@ -16,7 +16,10 @@ def report_suspension(wheels: Wheels) -> None:
 
 if __name__ == '__main__':
   ip_address = sys.argv[1]
+
+  # start a listener session without using a `with` clause
   listener = Listener(ip_address)
+  listener.start()
 
   try:
     while True:
@@ -25,6 +28,8 @@ if __name__ == '__main__':
       if not packet.flags.loading_or_processing and not packet.flags.paused:
         report_suspension(packet.wheels)
   finally:
+    # If you don't use a `with` clause, then you'll need to close the session afterwords. Session will also successfully close with CTRL+C
+    listener.close()
     curses.echo()
     curses.nocbreak()
     curses.endwin()

--- a/src/granturismo/intake/listener.py
+++ b/src/granturismo/intake/listener.py
@@ -54,14 +54,7 @@ class Listener(object):
       name='HeartbeatBackgroundThread')
 
   def __enter__(self):
-    # connect to socket
-    self._sock = self._init_sock_()
-    self._sock_bounded = True
-    self._decrypter = Decrypter()
-
-    # start heartbeat thread
-    self._heartbeat_thread.start()
-    return self
+    self.start()
 
   def __exit__(self, exc_type, exc_val, exc_tb):
     self.close()
@@ -71,6 +64,16 @@ class Listener(object):
 
   def __del__(self):
     self.close()
+
+  def start(self):
+    # connect to socket
+    self._sock = self._init_sock_()
+    self._sock_bounded = True
+    self._decrypter = Decrypter()
+
+    # start heartbeat thread
+    self._heartbeat_thread.start()
+    return self
 
   def close(self):
     """


### PR DESCRIPTION
Listener now has a `.start()` function which can be called independently from `with` clause.

Updated readme and examples